### PR TITLE
Fix config examples to use variables for user and db

### DIFF
--- a/README
+++ b/README
@@ -19,19 +19,19 @@ With 'stderr' log format, log line prefix must be at least:
 
 Log line prefix could add user and database name as follow:
 
-	log_line_prefix = '%t [%p]: [%l-1] user=username,db=dbname '
+	log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d '
 
 or for syslog log file format:
 
-	log_line_prefix = 'user=username,db=dbname '
+	log_line_prefix = 'user=%u,db=%d '
 
 Log line prefix for stderr output could also be:
 
-	log_line_prefix = '%t [%p]: [%l-1] db=dbname,user=username'
+	log_line_prefix = '%t [%p]: [%l-1] db=%d,user=%u '
 
 or for syslog output:
 
-	log_line_prefix = 'db=dbname,user=username'
+	log_line_prefix = 'db=%d,user=%u '
 
 Additional informations that could be collected need logging activation into postgresql.conf:
 

--- a/pgbadger
+++ b/pgbadger
@@ -12,6 +12,8 @@
 # Log line prefix should be : log_line_prefix = '%t [%p]: [%l-1] '
 # Log line prefix should be : log_line_prefix = '%t [%p]: [%l-1] user=username,db=dbname'
 # Log line prefix should be : log_line_prefix = '%t [%p]: [%l-1] db=dbname,user=username'
+# Log line prefix should be : log_line_prefix = '%t [%p]: [%l-1] user=%u,db=%d '
+# Log line prefix should be : log_line_prefix = '%t [%p]: [%l-1] db=%d,user=%u '
 #
 # Additional informations that could be collected and reported
 #


### PR DESCRIPTION
Just a small change to fix the example config to use the right variables.
