### PR TITLE
Fixed help text for --exclude-file

### DIFF
--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -56,7 +56,7 @@ Options:
     --exclude-query regex  : any query matching the given regex will be excluded
                              from the report. For example: "^(VACUUM|COMMIT)"
                              you can use this option multiple time.
-    --exclude_file filename: path of the file which contains all the regex to use
+    --exclude-file filename: path of the file which contains all the regex to use
                              to exclude queries from the report. One regex per line.
     --disable-error        : do not generate error report.
     --disable-hourly       : do not generate hourly reports.

--- a/pgbadger
+++ b/pgbadger
@@ -782,7 +782,7 @@ Options:
     --exclude-query regex  : any query matching the given regex will be excluded
 			     from the report. For example: "^(VACUUM|COMMIT)"
 			     you can use this option multiple time.
-    --exclude_file filename: path of the file which contains all the regex to use
+    --exclude-file filename: path of the file which contains all the regex to use
 			     to exclude queries from the report. One regex per line.
     --disable-error        : do not generate error report.
     --disable-hourly       : do not generate hourly reports.


### PR DESCRIPTION
Old help text indicated the option name was --exclude_text which was
incorrect.
