### PR TITLE
Clarify misleading statement about log_duration

### DIFF
--- a/README
+++ b/README
@@ -222,8 +222,8 @@ POSTGRESQL CONFIGURATION
             log_lock_waits = on
             log_temp_files = 0
 
-    Do not enable log_statement and log_duration as their log format will
-    not be parsed by pgBadger.
+    Do not enable log_statement, as the log format will not be parsed by
+    pgBadger.
 
     Of course your log messages should be in English without locale support:
 


### PR DESCRIPTION
log_duration may be turned on depending on desired information.
Only log_statement must not be on.
