### PR TITLE
Lintian errors fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ WriteMakefile(
 	'AUTHOR'       => 'Gilles Darold (gilles@darold.net)',
 	'ABSTRACT'     => 'pgBadger - PostgreSQL log analysis report',
 	'EXE_FILES'    => [ qw(pgbadger) ],
-	'MAN1PODS'     => { 'doc/pgBadger.pod' => 'blib/man1/pgbadger.1' },
+	'MAN1PODS'     => { 'doc/pgBadger.pod' => 'blib/man1/pgbadger.1p' },
 	'DESTDIR'      => $DESTDIR,
 	'INSTALLDIRS'  => $INSTALLDIRS,
 	'clean'	       => {},

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -1,4 +1,4 @@
-=head1 ABSTRACT
+=head1 NAME
 
 pgBadger - a fast PostgreSQL log analysis report
 


### PR DESCRIPTION
Guys,

Here is a quick fix of the following Lintian errors:
Now running lintian...
W: pgbadger: manpage-has-bad-whatis-entry usr/share/man/man1/pgbadger.1.gz
W: pgbadger: manpage-section-mismatch usr/share/man/man1/pgbadger.1.gz:127 1 != 1p
Finished running lintian.

Can you please merge this branch?

Regards,
