### PR TITLE
avoid "negative look behind not implemented" errors on perl 5.16/5.18

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -506,14 +506,21 @@ sub check_regex
 
 # Check start/end date time
 if ($from) {
-	if ($from !~ /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/) {
-		die "FATAL: bad format for begin datetime, should be yyyy-mm-dd hh:mm:ss\n";
-	}
+	if ($from !~ /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})([.]\d+([+-]\d+)?)?$/) {
+		die "FATAL: bad format for begin datetime, should be yyyy-mm-dd hh:mm:ss.l+tz\n";
+	} else {
+                my $fractional_seconds = $7 || "0";
+                $from = "$1-$2-$3 $4:$5:$6.$7"
+        }
+
 }
 if ($to) {
-	if ($to !~ /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/) {
-		die "FATAL: bad format for ending datetime, should be yyyy-mm-dd hh:mm:ss\n";
-	}
+	if ($to !~ /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})([.]\d+([+-]\d+)?)?$/) {
+		die "FATAL: bad format for ending datetime, should be yyyy-mm-dd hh:mm:ss.l+tz\n";
+	} else {
+                my $fractional_seconds = $7 || "0";
+                $from = "$1-$2-$3 $4:$5:$6.$7"
+        }
 }
 
 # Stores the last parsed line from log file to allow incremental parsing


### PR DESCRIPTION
The string ST (two characters) is the uppercase version of ﬆ (one character). Due to this the regular expression at line 5086:

```
$code =~ s/(?<!STYLESY0B\$\$)\b$KEYWORDS1[$x]\b/<span class="kw1">$KEYWORDS1[$x]<\/span>/igs;
```

Can have a variable length if the /i modifier is in use (as it is in this regexp). This patch simply disables the /i modifier inside the negative lookbehind (which is ok because we've added in the exact string we're matching against, and it didn't have a ﬆ in it.

Since i don't know how to (easily) split this into 3 pull requests there are two other changes in here as well:
1. use #!/usr/bin/env perl instead of #!/usr/bin/perl so that perlbrew'd perls can be used easily
2. handle the output of 'select now()::timestamp' as input to the -b and -e parameters.

these two are nice, but i wouldn't really call them bugs.
