### PR TITLE
Add a new option --outfile-slowest to output top slowest queries in file...

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -2955,12 +2955,11 @@ sub dump_slowest_queries
 
 	my $query = $top_slowest[$i]->[2];
 
-
 	my @KEYWORDS = qw(
            FROM INNER WHERE ORDER RETURNING); 
 
-	for (my $x = 0 ; $x <= $#KEYWORDS1 ; $x++) {
-	    $query =~ s/\s$KEYWORDS1/\n$KEYWORDS/igs;
+	for (my $x = 0 ; $x <= $#KEYWORDS ; $x++) {
+	    $query =~ s/\s$KEYWORDS[$x]/\n$KEYWORDS[$x]/igs;
 	}
 
 	$query =~ s/\)\sVALUES\s\(/\)\nVALUES\n\(/g;


### PR DESCRIPTION
My goal with this PR is to fetch from pgbadger all queries I'll analyze with explain. When the option is activate all top queries are output in a file beginning with comments, the EXPLAIN command is added at beginning of the queries so it is possible to play the file directly with **\i** or **psql -f**
