### PR TITLE
Add extra CSV parsing options to fix issues with JSON in queries.

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -1938,6 +1938,8 @@ sub process_file
 				eol => $/,
 				sep_char => $csv_sep_char,
 				allow_loose_quotes => 1,
+				allow_loose_escapes => 1,
+				escape_char => '"',
 			}
 		);
 


### PR DESCRIPTION
By allowing loose escapes and making sure that we escape " via "", we can process CSV query logs which have JSON in them.  Tested on socorro logs, which have some really long JSON fields.
