### PR TITLE
Do not return SUCCESS error code 0 when aborted or something fails

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -1256,7 +1256,7 @@ if ($last_parsed && $last_line{datetime} && $last_line{orig}) {
 	}
 }
 
-exit 0 if ($terminate);
+exit 2 if ($terminate);
 
 my $t1 = Benchmark->new;
 my $td = timediff($t1, $t0);
@@ -1843,7 +1843,7 @@ sub multiprocess_progressbar
 	# Terminate the process when we haven't read the complete file but must exit
 	local $SIG{USR1} = sub {
 		print STDERR "\n";
-		exit 0;
+		exit 1;
 	};
 	my $timeout  = 3;
 	my $cursize  = 0;


### PR DESCRIPTION
If you have some bash scripts that rely on the exit code in order to perform another action, if something fails, or is aborted, the next step will still happen. Example:

perl pgbadge <options> && echo "SUCESS"
