### PR TITLE
Add support to log_timezones with + and - signs

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -10677,7 +10677,7 @@ sub build_log_line_prefix_regex
 		'%r' => [('t_hostport',     '([a-zA-Z0-9\-\.]+|\[local\]|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|[0-9a-fA-F:]+)?[\(\d\)]*')],     # remote host and port
 		'%h' => [('t_client',       '([a-zA-Z0-9\-\.]+|\[local\]|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|[0-9a-fA-F:]+)?')],              # remote host
 		'%p' => [('t_pid',          '(\d+)')],                                                        # process ID
-		'%t' => [('t_timestamp',    '(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?: [A-Z\d]{3,6})?')],      # timestamp without milliseconds
+		'%t' => [('t_timestamp',    '(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?: [A-Z\+\-\d]{3,6})?')],      # timestamp without milliseconds
 		'%m' => [('t_mtimestamp',   '(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\.\d+(?: [A-Z\d]{3,6})?')], # timestamp with milliseconds
 		'%l' => [('t_session_line', '(\d+)')],                                                        # session line number
 		'%s' => [('t_session_timestamp', '(\d{4}-\d{2}-\d{2} \d{2}):\d{2}:\d{2}(?: [A-Z\d]{3,6})?')],    # session start timestamp


### PR DESCRIPTION
pgbadger does not recognize log files (queries and events) with timezones like 'GMT+3'.

On postgresql.conf file the log_timezone variable is set as 'Etc/GMT+3' and lines are generated like this (stderr format):
2014-12-19 00:02:40 GMT+3 [1981]: [239-1] user=,db= LOG:  checkpoint starting: time
