### PR TITLE
Do not lowercase queries

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -3530,9 +3530,6 @@ sub normalize_query
 	# Remove comments
 	$orig_query =~ s/\/\*(.*?)\*\///gs;
 
-	# Set the entire query lowercase
-	$orig_query = lc($orig_query);
-
 	# Remove extra space, new line and tab characters by a single space
 	$orig_query =~ s/\s+/ /gs;
 


### PR DESCRIPTION
One of pgBadger's benefits is that it provides concrete examples of slow queries – you can take them, EXPLAIN and optimize.

But if you use "CamelCase" names for tables, columns, etc – you're in trouble, because of the lines of code I removed in this PR.

It is clear that "select 1;" and "SELECT 1;" should be considered as equivalent, but it's better to have them placed to separate groups than to have destroyed, unusable query samples.

The next step to improve query grouping would be using https://github.com/lfittl/libpg_query to group queries.