### PR TITLE
t/02_basics.t: Don't fail if syslog test takes more than 10s

### DIFF
--- a/t/02_basics.t
+++ b/t/02_basics.t
@@ -42,7 +42,7 @@ chomp($ret);
 ok( $? == 0 && $ret eq '13453415984134534', "Multiple output format");
 
 $ret = `perl pgbadger -q -o - $SYSLOG`;
-ok( $? == 0 && length($ret) == 24281, "syslog report to stdout");
+ok( $? == 0 && (length($ret) == 24281 || length($ret) == 24282), "syslog report to stdout");
 
 `rm -f out.html`;
 # Remove files generated during the tests


### PR DESCRIPTION
The syslog test checks if the result is exactly 24281 bytes, but if the
run takes 10s or more, the result is longer.

Generated on Tue Feb 19 12:24:58 2019
Log file: t/fixtures/pg-syslog.1.bz2
Parsed 59,921 log entries in **19s**  <-- PROBLEM HERE
Log start from 2019-02-11 13:15:39 to 2019-02-11 13:16:26