### PR TITLE
Fix remote paths when using SSH.

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -2106,9 +2106,10 @@ sub set_file_list
 				my($filename, $dirs, $suffix) = fileparse($file);
 				&logmsg('DEBUG', "Looking for remote filename using command: $ssh $host_info \"ls '$dirs'$filename\"");
 				my @rfiles = `$ssh $host_info "ls '$dirs'$filename"`;
+        $dirs = '' if ( @rfiles <= 1 );
 				foreach my $f (@rfiles)
 				{
-					push(@lfiles, "ssh://$host_info/$f$fmt");
+					push(@lfiles, "ssh://$host_info/$dirs$f$fmt");
 				}
 			}
 			$empty_files = 0;


### PR DESCRIPTION
When specifying a directory instead of a remote file, the program aborts
with a message like:

% pgbadger  ssh://postgres@pghost//postgres/data/log/
FATAL: can't get size of remote file,
       please check what's going wrong with command:
       ssh postgres@pghost "ls -l postgresql-Fri.log"

The problem is that the set_file_list function does not include the path
on the remote host, managing each file path as relative. Therefore
now there is an addition of $dirs before pushing the path to the @lfiles array.
However, this is due only when there is a directory, that is when the number
of remote files on each function invocation is not equal at one.