### PR TITLE
Use $fractional_seconds instead of regexp $7.

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -891,7 +891,7 @@ if ($from) {
 		localdie("FATAL: bad format for begin datetime, should be yyyy-mm-dd hh:mm:ss.l+tz\n");
 	} else {
                 my $fractional_seconds = $7 || "0";
-                $from = "$1-$2-$3 $4:$5:$6.$7"
+                $from = "$1-$2-$3 $4:$5:$6.$fractional_seconds"
         }
 
 }
@@ -900,7 +900,7 @@ if ($to) {
 		localdie("FATAL: bad format for ending datetime, should be yyyy-mm-dd hh:mm:ss.l+tz\n");
 	} else {
                 my $fractional_seconds = $7 || "0";
-                $to = "$1-$2-$3 $4:$5:$6.$7"
+                $to = "$1-$2-$3 $4:$5:$6.$fractional_seconds"
         }
 }
 if ($from && $to && ($from gt $to)) {


### PR DESCRIPTION
When computing $from or $to variables the fractional seconds are placed
into $fractional_seconds but then they are not used.

Discovered while working on PR #501 , commit 67b7db0339daa6d92ec65c795a1059f77cec9340