### PR TITLE
Fix URI samples in documentation

### DIFF
--- a/README
+++ b/README
@@ -212,7 +212,7 @@ SYNOPSIS
     You can use together a local PostgreSQL log and a remote pgbouncer log
     file to parse:
 
-        pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username.12.110.14/pgbouncer.log
+        pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username@172.12.110.14/pgbouncer.log
 
     Generate Tsung sessions XML file with select queries only:
 

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -212,7 +212,7 @@ Use URI notation for remote log file:
 
 You can use together a local PostgreSQL log and a remote pgbouncer log file to parse:
 
-    pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username.12.110.14/pgbouncer.log
+    pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username@172.12.110.14/pgbouncer.log
 
 Generate Tsung sessions XML file with select queries only:
 

--- a/pgbadger
+++ b/pgbadger
@@ -2023,7 +2023,7 @@ Use URI notation for remote log file:
 
 You can use together a local PostgreSQL log and a remote pgbouncer log file to parse:
 
-    pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username@172.12.110.14/pgbouncer.log
+    pgbadger /var/log/postgresql/postgresql-10.1-main.log ssh://username\@172.12.110.14/pgbouncer.log
 
 Generate Tsung sessions XML file with select queries only:
 


### PR DESCRIPTION
again - was accidentially broken by bf2cb1e / forgotten in d9602a6 and d06af8b