### PR TITLE
fix SSH URIs for files, directories and wildcards

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -2219,7 +2219,7 @@ sub set_file_list
 				my($filename, $dirs, $suffix) = fileparse($file);
 				&logmsg('DEBUG', "Looking for remote filename using command: $ssh $host_info \"ls '$dirs'$filename\"");
 				my @rfiles = `$ssh $host_info "ls '$dirs'$filename"`;
-        $dirs = '' if ( @rfiles <= 1 );
+				$dirs = '' if ( $filename ne '' ); #ls returns relative paths for an directory but absolute ones for a file or filename pattern 
 				foreach my $f (@rfiles)
 				{
 					push(@lfiles, "ssh://$host_info/$dirs$f$fmt");


### PR DESCRIPTION
835231a / PR #500 did break again the use of wildcards in SSH URI filenames that 0a45659 / #477 took care of. This patch should finally offer a solution that can deal with absolute and relative paths, spaces in paths, wildcards in filenames, single files and whole directories within the URI.