### PR TITLE
Update README to reference 11.x instead of 7.x

### DIFF
--- a/README
+++ b/README
@@ -439,8 +439,8 @@ REQUIREMENT
 INSTALLATION
     Download the tarball from GitHub and unpack the archive as follow:
 
-            tar xzf pgbadger-7.x.tar.gz
-            cd pgbadger-7.x/
+            tar xzf pgbadger-11.x.tar.gz
+            cd pgbadger-11.x/
             perl Makefile.PL
             make && sudo make install
 


### PR DESCRIPTION
Installation instructions currently indicate 7.x as the current version, while 11.x is the current release.