### PR TITLE
Fall back to default fle size when totalsize could not be determined

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -16759,10 +16759,13 @@ sub get_file_size
 			$totalsize = `$cmd_file_size`;
 
 			chomp($totalsize);
-			# lz4 archive must be compressed with --content-size option to determine size. If not $totalsize is '-'
-			if ($logf =~ /\.lz4$/i && $totalsize eq "-") {
-				&logmsg('DEBUG', "Can't determine file size. Maybe file compressed without --content-size option ?");
-
+			if ($totalsize !~ /\d+/) {
+				if ($logf =~ /\.lz4$/i) {
+					# lz4 archive must be compressed with --content-size option to determine size. If not $totalsize is '-'
+					&logmsg('DEBUG', "Can't determine lz4 file size. Maybe file compressed without --content-size option ?");
+				} else {
+					&logmsg('DEBUG', "Can't determine uncompressed file size. Guess with compressed size * $XZ_FACTOR");
+				}
 				# Thus we use a hack to determine size
 				$cmd_file_size = "ls -l '%f' | awk '{print \$5}'";
 				$cmd_file_size =~ s/\%f/$logf/g;


### PR DESCRIPTION
Hello Gilles,

Sometimes it is not possible to detect uncompressed file size. I suggest to fall back to default compressed size multiplied by `$XZ_FACTOR`.

Here is my use case, we compress postgres logs by sending log to stdin (look `<`):

```
zstd --compress --stdout < /var/log/postgresql/postgresql-10-main.log > pg.log.zst
```

(We do like this because zstd do not like to compress a modified file during compression. see there for the complete explanation https://github.com/facebook/zstd/issues/1926#issuecomment-564170480)


Here is a debug output of pgbadger : 
```
DEBUG: timezone not specified, using 0 seconds
DEBUG: Output 'html' reports will be written to out.html
DEBUG: Looking for file size using command: zstd -v -l pg.log.zst |grep Decompressed | awk  -F"[ (]*" '{print $5}'
*** zstd command line interface 64-bits v1.3.8, by Yann Collet ***
DEBUG: Starting progressbar writer process
DEBUG: Can not autodetect log format from pg.log.zst, using default
DEBUG: pgBadger will use log format default to parse pg.log.zst.
DEBUG: Processing log file: pg.log.zst
DEBUG: Starting reading file "pg.log.zst"...
DEBUG: Start parsing postgresql log at offset 0 of file "pg.log.zst" to 
Can't call method "seek" on an undefined value at ./pgbadger line 3540.

DEBUG: the log statistics gathering took: 2 wallclock secs ( 0.00 usr +  0.00 sys =  0.00 CPU)
DEBUG: Output 'html' reports will be written to out.html
LOG: Ok, generating html report...
DEBUG: building reports took:  0 wallclock secs ( 0.01 usr +  0.01 sys =  0.02 CPU)
DEBUG: the total execution time took:  2 wallclock secs ( 0.01 usr +  0.01 sys =  0.02 CPU)
```


As you can see, header doesn't container `Decompressed` size:
```
zstd -v -l pg.log.zst 
*** zstd command line interface 64-bits v1.3.8, by Yann Collet ***
pg.log.zst 
# Zstandard Frames: 1
Window Size: 2048.00 KB (2097152 B)
Compressed Size: 399.40 KB (408986 B)
Check: XXH64
```

Is see two issues here:

1. pgbadger do not throw an error, you can think everything is fine but the report is empty. (Could be an issue for report generated with crontab for example)
2. It should fall back to another method when it can't determine uncompressed file size

This PR propose to solve 2.

Furthermore, I think pgbadger should check if $totalsize is a number by the end of get_file_size, if it is not the case it should throw an error. As it means we didn't correctly detect file size in the function.

Regards,