### PR TITLE
fixes the commandline parameter from --no-explain to --noexplain

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -540,7 +540,7 @@ my $result = GetOptions(
 	'log-timezone=i'	   => \$log_timezone,
 	'prettify-json!'	   => \$json_prettify,
 	'month-report=s'	   => \$month_report,
-	'no-explain!'              => \$noexplain,
+	'noexplain!'               => \$noexplain,
 	'command=s'                => \$log_command,
 );
 die "FATAL: use pgbadger --help\n" if (not $result);


### PR DESCRIPTION
https://github.com/darold/pgbadger/commit/ec85319e119bce8e86c885debb2f863aaa9c57e3 introduced  a new command line option `--noexplain` but in the source the option is actually spelled like `--no-explain`