### PR TITLE
Typo in parameter for html directory output

### DIFF
--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -38,7 +38,7 @@ Options:
 			     format.
     -G | --nograph	   : disable graphs on HTML output. Enabled by default.
     -h | --help	           : show this message and exit.
-    -H | --html-dir path   : path to directory where HTML report must be written
+    -H | --html-outdir path: path to directory where HTML report must be written
                              in incremental mode, binary files stay on directory
 			     defined with -O, --outdir option.
     -i | --ident name      : programname used as syslog ident. Default: postgres


### PR DESCRIPTION
Simple mismatch in docs vs code