### PR TITLE
Parse times with T's

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -406,7 +406,7 @@ my $num_sep = ',';
 $num_sep = ' ' if ($n =~ /,/);
 
 # Set iso datetime pattern
-my $time_pattern = qr/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/;
+my $time_pattern = qr/(\d{4})-(\d{2})-(\d{2})[\sT](\d{2}):(\d{2}):(\d{2})/;
 
 # Inform the parent that it should stop iterate on parsing other files
 sub stop_parsing


### PR DESCRIPTION
This allows using the timestamp from journalctl, using the following
incantation:

    pgbadger --journalctl 'journalctl -u postgresql' \
        --prefix "%t\+\d+ .*[%p]: user=%u,db=%d,app=%a,client=%h "

where the database has the following log prefix configured:

    user=%u,db=%d,app=%a,client=%h