### PR TITLE
Add 'g' option to replace all bind parameters not only the first found

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -16454,7 +16454,7 @@ sub store_queries
 			my @t_res = split(/[,\s]*\$(\d+)\s=\s/, $cur_info{$t_pid}{parameters});
 			shift(@t_res);
 			for (my $i = 0 ; $i < $#t_res ; $i += 2) {
-				$cur_info{$t_pid}{query} =~ s/\$$t_res[$i]\b/$t_res[$i+1]/s;
+				$cur_info{$t_pid}{query} =~ s/\$$t_res[$i]\b/$t_res[$i+1]/gs;
 			}
 		}
 		else
@@ -16464,7 +16464,7 @@ sub store_queries
 			for (my $i = 0 ; $i <= $#t_res ; $i++)
 			{
 				my $num = $i + 1;
-				$cur_info{$t_pid}{query} =~ s/\$$num\b/$t_res[$i]/s;
+				$cur_info{$t_pid}{query} =~ s/\$$num\b/$t_res[$i]/gs;
 			}
 		}
 		return if ($cur_info{$t_pid}{query} =~ /^parameters:/);


### PR DESCRIPTION
For one query if there are multiple same bind parameters, it could be interesting to replace all of them.
It's very usefull to replay  slow queries for example . 

For example with this log : 
~~~
2021-04-19 06:20:26 CEST [133854]: [1-1] db=test,user=user1 LOG:  duration: 346.806 ms  execute 7048305f4c4ba9537a8ae75d60c84457: SELECT
	        t1."id" as "id", t1."o_id" as "o_id"
	    FROM
	        table1 t1
	    WHERE t1."o_id" = $1
	        AND t1."p_id" = $2
	    UNION ALL
	    SELECT
	        t2."id" as "id", t2."o_id" as "o_id"
	    FROM
	        table2 t2
	    WHERE t2."o_id" = $1
	        AND t2."p_id" = $2

2021-04-19 06:20:26 CEST [133854]: [2-1] db=test,user=user1 DETAIL:  parameters: $1 = 'xxxxxxx-a92a-4dc4-yyyy-e74892d4906f', $2 = 'xxxxxxx-9cc5-456d-yyyy-b7032123b7b2'
~~~

With the current version with this command : pgbadger -f  --no-prettify --nocomment --dump-all-queries /tmp/logtest.log 
the result is : 
~~~
SELECT
                t1."id" as "id", t1."o_id" as "o_id"
            FROM
                table1 t1
            WHERE t1."o_id" = 'xxxxxxx-a92a-4dc4-yyyy-e74892d4906f'
                AND t1."p_id" = 'xxxxxxx-9cc5-456d-yyyy-b7032123b7b2'
            UNION ALL
            SELECT
                t2."id" as "id", t2."o_id" as "o_id"
            FROM
                table2 t2
            WHERE t2."o_id" = $1
                AND t2."p_id" = $2
~~~
we have this output with this fix : 

~~~
SELECT
                t1."id" as "id", t1."o_id" as "o_id"
            FROM
                table1 t1
            WHERE t1."o_id" = 'xxxxxxx-a92a-4dc4-yyyy-e74892d4906f'
                AND t1."p_id" = 'xxxxxxx-9cc5-456d-yyyy-b7032123b7b2'
            UNION ALL
            SELECT
                t2."id" as "id", t2."o_id" as "o_id"
            FROM
                table2 t2
            WHERE t2."o_id" = 'xxxxxxx-a92a-4dc4-yyyy-e74892d4906f'
                AND t2."p_id" = 'xxxxxxx-9cc5-456d-yyyy-b7032123b7b2';
~~~



