### PR TITLE
Fixes #662 related to timezone calculations

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -18503,7 +18503,7 @@ sub change_timezone
 
 	my $t = timegm_nocheck($s, $mi, $h, $d, $mo-1, $y-1900);
 	$t += $log_timezone;
-	($s, $mi, $h, $d, $mo, $y) = localtime($t);
+	($s, $mi, $h, $d, $mo, $y) = gmtime($t);
 
 	return ($y+1900, sprintf("%02d", ++$mo), sprintf("%02d", $d), sprintf("%02d", $h), sprintf("%02d", $mi), sprintf("%02d", $s));
 }

--- a/t/03_consistency.t
+++ b/t/03_consistency.t
@@ -1,4 +1,4 @@
-use Test::Simple tests => 19;
+use Test::Simple tests => 20;
 use JSON::XS;
 
 my $json = new JSON::XS;
@@ -82,3 +82,7 @@ ok( $? == 0 && $ret eq 'Total number of sessions: 2', "Generate report from incl
 $ret = `perl pgbadger -q -p "%t [%p]: db=%d,user=%u,app=%a,client=%h " -o - $TIMELOG --exclude-time "2021-02-14 2[01]:.*" | grep '^Total number of sessions:'`;
 chomp($ret);
 ok( $? == 0 && $ret eq 'Total number of sessions: 6', "Generate report from exclude time");
+
+$ret = `perl pgbadger -q --log-timezone +5 -p "%t:%h:%u@%d:[%p]:" -o - t/fixtures/pg-timezones.log`;
+chomp($ret);
+ok( $? == 0 && $ret =~ m{Log start from 2021-05-27 12:00:00 to 2021-05-27 12:46:39} , "Correct first and last query timestamps on timezone adjusted log");

--- a/t/fixtures/pg-timezones.log
+++ b/t/fixtures/pg-timezones.log
@@ -1,0 +1,2 @@
+2021-05-27 17:00:00 UTC:10.1.91.65:user@my_db:[24743]:LOG: duration: 0.054 ms statement: SELECT * FROM t1;
+2021-05-27 17:46:39 UTC:10.1.17.194:user@my_db:[19003]:LOG: duration: 0.060 ms statement: UPDATE t1 SET c1=1;


### PR DESCRIPTION
In the function change_timezone, localtime was used on a time returned
by timegm_nocheck.

In [1] [2] it's mentioned that timegm_nocheck is the inverse of gmtime and
timelocal_nocheck the inverse of localtime.

This commit also adds a regression test.

[1] https://man7.org/linux/man-pages/man3/timegm.3.html
[2] https://perldoc.perl.org/Time::Local