### PR TITLE
fix input according to locale rather perlio default

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -51,6 +51,7 @@ use FileHandle;
 use Socket;
 use constant EBCDIC => "\t" ne "\011";
 use Encode qw(encode decode);
+use open ':locale';
 
 $VERSION = '11.5';
 


### PR DESCRIPTION
If logs contains UTF-8 characters JSON output embeds "badly converted" characters :

~~~
echo "2021-06-08 13:51:04.966 UTC [22436-2] postgres@postgres LOG:  duration: 5025.921 ms  statement: select ' € € ', pg_sleep(5);"|perl pgbadger -x json -f stderr  -p '%m [%p-%l] %q%u@%d ' -o /tmp/test.json - && cat /tmp/test.json | jq . |grep sleep
[+] Parsed 129 bytes, queries: 1, events: 0
LOG: Ok, generating json report...
      "select ?, pg_sleep(?);": {
            "query": "select ' â¬ â¬ ', pg_sleep(5);",
        "select ' â¬ â¬ ', pg_sleep(5);",
~~~

This patch produces a correct query output with the given locale (locale should be adapted to input file locale) :

~~~
echo "2021-06-08 13:51:04.966 UTC [22436-2] postgres@postgres LOG:  duration: 5025.921 ms  statement: select ' € € ', pg_sleep(5);"|LANG=en_US.UTF-8 perl pgbadger -x json -f stderr  -p '%m [%p-%l] %q%u@%d ' -o /tmp/test.json - && cat /tmp/test.json | jq . |grep sleep
[+] Parsed 125 bytes, queries: 1, events: 0
LOG: Ok, generating json report...
        "select ' € € ', pg_sleep(5);",
      "select ?, pg_sleep(?);": {
            "query": "select ' € € ', pg_sleep(5);",
~~~

I didn't made extended tests on other output formats though it would be useful to be sure there won't be any regression.

Here are the simple tests I've made :

~~~shell
for fmt in 'html' 'tsung' 'text'; do 
         echo "***** ${fmt} *****"
        echo "2021-06-08 13:51:04.966 UTC [22436-2] postgres@postgres LOG:  duration: 5025.921 ms  statement: select ' € € ', pg_sleep(5);"|perl pgbadger -x ${fmt} -f stderr  -p '%m [%p-%l] %q%u@%d ' -o /tmp/test - && cat /tmp/test  |grep sleep
done
~~~

and outputs 

~~~
***** html *****
[+] Parsed 125 bytes, queries: 1, events: 0
LOG: Ok, generating html report...
Wide character in print at pgbadger line 11618, <DATA> line 122.
Wide character in print at pgbadger line 11865, <DATA> line 122.
Wide character in print at pgbadger line 12120, <DATA> line 122.
Wide character in print at pgbadger line 12375, <DATA> line 122.
    <span class="kw2">pg_sleep</span><span class="br0">(</span><span class="nu0">5</span><span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span>?<span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span><span class="nu0">5</span><span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span>?<span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span><span class="nu0">5</span><span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span>?<span class="br0">)</span>;
    <span class="kw2">pg_sleep</span><span class="br0">(</span><span class="nu0">5</span><span class="br0">)</span>;
***** tsung *****
Wide character in print at pgbadger line 16443.
Illegal division by zero at pgbadger line 17512, <GEN3> line 1.
LOG: Ok, generating tsung report...
    <request><pgsql type='sql'><![CDATA[select ' € € ', pg_sleep(5);]]></pgsql></request>
***** text *****
[+] Parsed 125 bytes, queries: 1, events: 0
LOG: Ok, generating text report...
Wide character in print at pgbadger line 5783, <DATA> line 122.
Wide character in print at pgbadger line 5808, <DATA> line 122.
Wide character in print at pgbadger line 5820, <DATA> line 122.
Wide character in print at pgbadger line 5848, <DATA> line 122.
Wide character in print at pgbadger line 5860, <DATA> line 122.
Wide character in print at pgbadger line 5888, <DATA> line 122.
Wide character in print at pgbadger line 5900, <DATA> line 122.
1) 5s25ms database: postgres, user: postgres - select ' € € ', pg_sleep(5);
1) 5s25ms - 1 - 5s25ms/5s25ms/5s25ms - select ' € € ', pg_sleep(5);
	- Example 1: 5s25ms - database: postgres, user: postgres - select ' € € ', pg_sleep(5);
1) 1 - 5s25ms - 5s25ms/5s25ms/5s25ms - select ' € € ', pg_sleep(5);
	Example 1: 5s25ms - database: postgres, user: postgres - select ' € € ', pg_sleep(5);
1) 5s25ms/5s25ms/5s25ms - 1 - 5s25ms - select ' € € ', pg_sleep(5);
	Example 1: 5s25ms - database: postgres, user: postgres - select ' € € ', pg_sleep(5);
~~~

It's quite basic (rough) but it shows up "Wide Character in print" warnings :
  *  For the HTML output it seems to be (top queries). 
  * For text files output seems fine also. 
  * json file is ok.

I'd like to get rid of such warning messages though  could you give me more kind guidelines to finish this PR without warning (your thoughts).  If not possible I'll try to find a correct way by myself.

Please take note of tsung output with illegal division by zero on line 

~~~perl
sprintf(
                        "[%-${width}s] Parsed %${num_width}s bytes of %s (%.2f%%), $lbl: %d\r",
                        $char x $nchars . '>',
                        $got, $total, 100 * $got / +$total, ($queries || $overall_stat{'queries_number'})
                );

~~~

where `$total` seems to be zero.  Others output treats it like this `(+$total||1)`

If this fix is correct, I'll include it in another PR.

Thanks for creating pgbadger, it's an everyday friend for me !