### PR TITLE
t/04_advanced.t: Fix syslog test

### DIFF
--- a/t/04_advanced.t
+++ b/t/04_advanced.t
@@ -27,7 +27,7 @@ ok( $? == 0 && ($ret == 4), "Test incremental mode with --explode");
 
 `rm -rf $incr_outdir/*`;
 
-$ret = `perl pgbadger -q --dbname=pgbench --explode -I -O $incr_outdir $SYSLOG1 $SYSLOG2 && ls $incr_outdir | grep ">12,474 queries" $incr_outdir/pgbench/2021/week-07/index.html`;
+$ret = `perl pgbadger -q --dbname=pgbench --explode -I -O $incr_outdir $SYSLOG1 $SYSLOG2 && ls $incr_outdir | grep ">12,474 queries" $incr_outdir/pgbench/20*/week-0*/index.html`;
 chomp($ret);
 ok( $? == 0 && ($ret ne ''), "Test incremental mode with --explode and --dbname");
 


### PR DESCRIPTION
Syslog timestamps do not contain the year, so what used to get
interpreted as February 2021 is now February 2022. Fix by using
wildcards in the grep command.

Close #715.