### PR TITLE
fix typo: 2919 to 2019

### DIFF
--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -330,7 +330,7 @@ but pgBadger can parse both formats.
 
 To create a cumulative report over a month use command:
 
-    pgbadger --month-report 2919-05 /path/to/incremental/reports/
+    pgbadger --month-report 2019-05 /path/to/incremental/reports/
 
 this will add a link to the month name into the calendar view in
 incremental reports to look at report for month 2019 May.
@@ -699,7 +699,7 @@ By default, pgBadger in incremental mode only computes daily and weekly reports.
 If you want monthly cumulative reports, you will have to use a separate command
 to specify the report to build. For example, to build a report for August 2019:
 
-    pgbadger -X --month-report 2919-08 /var/www/pg_reports/
+    pgbadger -X --month-report 2019-08 /var/www/pg_reports/
 
 this will add a link to the month name into the calendar view of incremental
 reports to look at monthly report. The report for a current month can be run
@@ -709,7 +709,7 @@ default because it could take a lot of time following the amount of data.
 If reports were built with the per-database option ( -E | --explode ), it must
 be used too when calling pgbadger to build monthly report:
 
-    pgbadger -E -X --month-report 2919-08 /var/www/pg_reports/
+    pgbadger -E -X --month-report 2019-08 /var/www/pg_reports/
 
 This is the same when using the rebuild option ( -R | --rebuild ).
 


### PR DESCRIPTION
I think this is a typo as the description states August 2019.