### PR TITLE
Use https for explain URL by default

### DIFF
--- a/README
+++ b/README
@@ -190,7 +190,7 @@ SYNOPSIS
         --no-week              : inform pgbadger to not build weekly reports in
                                  incremental mode. Useful if it takes too much time.
         --explain-url URL      : use it to override the url of the graphical explain
-                                 tool. Default: http://explain.depesz.com/
+                                 tool. Default: https://explain.depesz.com/
         --tempdir DIR          : set directory where temporary files will be written
                                  Default: File::Spec->tmpdir() || '/tmp'
         --no-process-info      : disable changing process title to help identify

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Options:
     --no-week              : inform pgbadger to not build weekly reports in
                              incremental mode. Useful if it takes too much time.
     --explain-url URL      : use it to override the url of the graphical explain
-                             tool. Default: http://explain.depesz.com/
+                             tool. Default: https://explain.depesz.com/
     --tempdir DIR          : set directory where temporary files will be written
                              Default: File::Spec->tmpdir() || '/tmp'
     --no-process-info      : disable changing process title to help identify

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -192,7 +192,7 @@ Options:
     --no-week              : inform pgbadger to not build weekly reports in
                              incremental mode. Useful if it takes too much time.
     --explain-url URL      : use it to override the url of the graphical explain
-                             tool. Default: http://explain.depesz.com/
+                             tool. Default: https://explain.depesz.com/
     --tempdir DIR          : set directory where temporary files will be written
                              Default: File::Spec->tmpdir() || '/tmp'
     --no-process-info      : disable changing process title to help identify

--- a/pgbadger
+++ b/pgbadger
@@ -71,7 +71,7 @@ my $MAX_QUERY_LENGTH = 25000;
 my $terminate = 0;
 my %CACHE_DNS = ();
 my $DNSLookupTimeout = 1; # (in seconds)
-my $EXPLAIN_URL = 'http://explain.depesz.com/';
+my $EXPLAIN_URL = 'https://explain.depesz.com/';
 my $EXPLAIN_POST = qq{<form method="POST" target="explain" action="%s"><input type="hidden" name="is_public" value="0"><input type="hidden" name="is_anon" value="0"><input type="hidden" name="plan" value=""></form>};
 my $PID_DIR = $TMP_DIR;
 my $PID_FILE = undef;


### PR DESCRIPTION
Opening the generated HTML reported on a server makes Chrome complain with:
> Mixed Content: The page at 'https://example.com/…' was loaded over a secure connection, but contains a form that targets an insecure endpoint 'http://explain.depesz.com/'. This endpoint should be made available over a secure connection.

Since explain.depesz.com works over HTTPS there is no reason not to use it by default.