### PR TITLE
--help: %p/%t must be there

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -2116,8 +2116,10 @@ Options:
 			     defined in your postgresql.conf. Only use it if you
 			     aren't using one of the standard prefixes specified
 			     in the pgBadger documentation, such as if your
-			     prefix includes additional variables like client ip
-			     or application name. See examples below.
+			     prefix includes additional variables like client IP
+			     or application name. MUST contain escape sequences
+			     for time (%t, %m or %n) and processes (%p or %c).
+			     See examples below.
     -P | --no-prettify     : disable SQL queries prettify formatter.
     -q | --quiet	   : don't print anything to stdout, not even a progress
 			     bar.


### PR DESCRIPTION
Yes, it is in the doc on the website, but in the `--help` it would have spared me some time. I didn't know that %p was compulsory, as most customers do keep it - not all of them.