### PR TITLE
Nit-fix: `Queries Average duration` -> `Average Query Duration`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1281,7 +1281,7 @@ New pgbouncer reports are:
 
   * Request Throughput
   * Bytes I/O Throughput
-  * Queries Average duration
+  * Average Query Duration
   * Simultaneous sessions
   * Histogram of sessions times
   * Sessions per database

--- a/README
+++ b/README
@@ -430,7 +430,7 @@ FEATURE
 
             Request Throughput
             Bytes I/O Throughput
-            Queries Average duration
+            Average Query Duration
             Simultaneous sessions
             Histogram of sessions times
             Sessions per database

--- a/README
+++ b/README
@@ -68,8 +68,10 @@ SYNOPSIS
                                  defined in your postgresql.conf. Only use it if you
                                  aren't using one of the standard prefixes specified
                                  in the pgBadger documentation, such as if your
-                                 prefix includes additional variables like client ip
-                                 or application name. See examples below.
+                                 prefix includes additional variables like client IP
+                                 or application name. MUST contain escape sequences
+                                 for time (%t, %m or %n) and processes (%p or %c).
+                                 See examples below.
         -P | --no-prettify     : disable SQL queries prettify formatter.
         -q | --quiet           : don't print anything to stdout, not even a progress
                                  bar.

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ reports:
 
         Request Throughput
         Bytes I/O Throughput
-        Queries Average duration
+        Average Query Duration
         Simultaneous sessions
         Histogram of sessions times
         Sessions per database

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -425,7 +425,7 @@ reports:
 
 	Request Throughput
 	Bytes I/O Throughput
-	Queries Average duration
+	Average Query Duration
 	Simultaneous sessions
 	Histogram of sessions times
 	Sessions per database

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -70,8 +70,10 @@ Options:
 			     defined in your postgresql.conf. Only use it if you
 			     aren't using one of the standard prefixes specified
 			     in the pgBadger documentation, such as if your
-			     prefix includes additional variables like client ip
-			     or application name. See examples below.
+			     prefix includes additional variables like client IP
+			     or application name. MUST contain escape sequences
+			     for time (%t, %m or %n) and processes (%p or %c).
+			     See examples below.
     -P | --no-prettify     : disable SQL queries prettify formatter.
     -q | --quiet	   : don't print anything to stdout, not even a progress
 			     bar.

--- a/pgbadger
+++ b/pgbadger
@@ -7141,7 +7141,7 @@ $EXPLAIN_POST
 			print $fh qq{
      				<li><a href="#pgbsql-traffic">Request Throughput</a></li>
      				<li><a href="#pgbbytes-traffic">Bytes I/O Throughput</a></li>
-     				<li><a href="#pgbduration-traffic">Queries Average duration</a></li>
+     				<li><a href="#pgbduration-traffic">Average Query Duration</a></li>
 				<li class="divider"></li>
      				<li><a href="#pgbsimultaneous-sessions">Simultaneous sessions</a></li>
 };
@@ -7930,7 +7930,7 @@ $drawn_graphs{pgb_bytepersecond_graph}
 
 	print $fh qq{
 	<div id="pgbduration-traffic" class="analysis-item row">
-		<h2 class="col-md-12"><i class="glyphicon icon-time"></i> Queries Average duration</h2>
+		<h2 class="col-md-12"><i class="glyphicon icon-time"></i> Average Query Duration</h2>
 		<div class="col-md-3">
 			<h3 class="">Key values</h3>
 			<div class="well key-figures">


### PR DESCRIPTION
Hello again, @darold !

While I was working on #788, I noticed this small incongruency between the plot name and the title on the upper left corner, so I thought I'd suggesta a fix for it too.

![image](https://github.com/darold/pgbadger/assets/36642413/accfac0e-346f-4104-8ae4-755631bfb599)


Also, I believe that there was some drift as to updating the docs from #781 so I did that too.