### PR TITLE
Add support for `{max,avg,min} autovacuum duration` & fix `autovacuum`'s `system usage: CPU: ...` line parsing

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -10513,6 +10513,8 @@ sub print_vacuum
 				my $rd = &average_per_minutes($m, $avg_minutes);
 				$v_dataavg{acount}{"$rd"} = 0 if (!exists $v_dataavg{acount}{"$rd"});
 				$v_dataavg{vcount}{"$rd"} = 0 if (!exists $v_dataavg{vcount}{"$rd"});
+				$v_dataavg{vmax}{"$rd"} = 0 if (!exists $v_dataavg{vmax}{"$rd"});
+				$v_dataavg{vmin}{"$rd"} = 0 if (!exists $v_dataavg{vmin}{"$rd"});
 
 				if (exists $per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}) {
 					$v_dataavg{vcount}{"$rd"} += ($per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{count} || 0);

--- a/pgbadger
+++ b/pgbadger
@@ -4970,7 +4970,7 @@ sub parse_orphan_line
 		if ($line =~ /(\d+) are dead but not yet removable/) {
 			$autovacuum_info{$curdb}{tables}{$cur_info{$cur_pid}{vacuum}}{tuples}{notremovable} += $1;
 		}
-		if ($line =~ m#^\t?system usage: CPU .* (?:sec|s,) elapsed (.*) s#)
+		if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*)/)
 		{
 			if ($1 > $autovacuum_info{$curdb}{peak}{system_usage}{elapsed})
 			{

--- a/pgbadger
+++ b/pgbadger
@@ -15182,6 +15182,11 @@ sub load_stats
 					$per_minute_info{$curdb}{$day}{$hour}{$min}{query}{min} = $_per_minute_info{$curdb}{$day}{$hour}{$min}{query}{min} if (!exists $per_minute_info{$curdb}{$day}{$hour}{$min}{query}{min} || ($per_minute_info{$curdb}{$day}{$hour}{$min}{query}{min} > $_per_minute_info{$curdb}{$day}{$hour}{$min}{query}{min}));
 					$per_minute_info{$curdb}{$day}{$hour}{$min}{query}{max} = $_per_minute_info{$curdb}{$day}{$hour}{$min}{query}{max} if (!exists $per_minute_info{$curdb}{$day}{$hour}{$min}{query}{max} || ($per_minute_info{$curdb}{$day}{$hour}{$min}{query}{max} < $_per_minute_info{$curdb}{$day}{$hour}{$min}{query}{max}));
 
+					foreach my $sec (keys %{ $_per_minute_info{$curdb}{$day}{$hour}{$min}{autovacuum}{second} })
+					{
+						$per_minute_info{$curdb}{$day}{$hour}{$min}{autovacuum}{second}{$sec} +=
+							($_per_minute_info{$curdb}{$day}{$hour}{$min}{autovacuum}{second}{$sec} || 0);
+					}
 					foreach my $sec (keys %{ $_per_minute_info{$curdb}{$day}{$hour}{$min}{connection}{second} })
 					{
 						$per_minute_info{$curdb}{$day}{$hour}{$min}{connection}{second}{$sec} +=

--- a/pgbadger
+++ b/pgbadger
@@ -10545,6 +10545,16 @@ sub print_vacuum
 					next if ($t < $t_min);
 					last if ($t > $t_max);
 
+					if (scalar keys %v_dataavg) {
+						# Average autovacuums per minute
+						$graph_data{autovacuum_avg} .= "[$t, " . int(($v_dataavg{vcount}{"$rd"} || 0) / (60 * $avg_minutes)) . "],";
+
+						# Max connections per minute
+						$graph_data{autovacuum_max} .= "[$t, " . ($v_dataavg{vmax}{"$rd"} || 0) . "],";
+
+						# Min connections per minute
+						$graph_data{autovacuum_min} .= "[$t, " . ($v_dataavg{vmin}{"$rd"} || 0) . "],";
+					}
 					if (exists $v_dataavg{vcount}{"$rd"}) {
 						$graph_data{vcount} .= "[$t, " . ($v_dataavg{vcount}{"$rd"} || 0) . "],";
 					}

--- a/pgbadger
+++ b/pgbadger
@@ -4948,6 +4948,7 @@ sub parse_jsoncnpg_input
 sub parse_orphan_line
 {
 	my ($cur_pid, $line, $t_dbname) = @_;
+	my $date_part = "$cur_info{$cur_pid}{year}$cur_info{$cur_pid}{month}$cur_info{$cur_pid}{day}";
 
 	my $curdb = undef;
 	if (!exists $cur_info{$cur_pid} || !exists $cur_info{$cur_pid}{cur_db} || !$cur_info{$cur_pid}{cur_db}) {

--- a/pgbadger
+++ b/pgbadger
@@ -4971,7 +4971,6 @@ sub parse_orphan_line
 			$autovacuum_info{$curdb}{tables}{$cur_info{$cur_pid}{vacuum}}{tuples}{notremovable} += $1;
 		}
 		if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: ([^\s]+)/)
-		#if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*)/)
 		{
 			# Add vacuum counts and duration to the $per_minute_info.
 			$per_minute_info{$curdb}{$date_part}{$cur_info{$cur_pid}{hour}}{$cur_info{$cur_pid}{min}}{autovacuum}{count}++;
@@ -10636,6 +10635,8 @@ print $fh qq{
 		<h3 class="">Key values</h3>
 		<div class="well key-figures">
 			<ul>
+				<li><span class="figure">$autovacuum_info{$curdb}{peak}{system_usage}{elapsed} sec</span> <span class="figure-label">Highest CPU-cost vacuum <br />Table $autovacuum_info{$curdb}{peak}{system_usage}{table} <br />Database $autovacuum_peak_system_usage_db</span></li>
+				<li><span class="figure">$autovacuum_info{$curdb}{peak}{system_usage}{date}</span> <span class="figure-label">Date</span></li>
 			</ul>
 		</div>
 	</div>

--- a/pgbadger
+++ b/pgbadger
@@ -4970,7 +4970,8 @@ sub parse_orphan_line
 		if ($line =~ /(\d+) are dead but not yet removable/) {
 			$autovacuum_info{$curdb}{tables}{$cur_info{$cur_pid}{vacuum}}{tuples}{notremovable} += $1;
 		}
-		if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*)/)
+		if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: ([^\s]+)/)
+		#if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*)/)
 		{
 			# Add vacuum counts and duration to the $per_minute_info.
 			$per_minute_info{$curdb}{$date_part}{$cur_info{$cur_pid}{hour}}{$cur_info{$cur_pid}{min}}{autovacuum}{count}++;

--- a/pgbadger
+++ b/pgbadger
@@ -10549,10 +10549,10 @@ sub print_vacuum
 						# Average autovacuums per minute
 						$graph_data{autovacuum_avg} .= "[$t, " . int(($v_dataavg{vcount}{"$rd"} || 0) / (60 * $avg_minutes)) . "],";
 
-						# Max connections per minute
+						# Max autovacuums per minute
 						$graph_data{autovacuum_max} .= "[$t, " . ($v_dataavg{vmax}{"$rd"} || 0) . "],";
 
-						# Min connections per minute
+						# Min autovacuums per minute
 						$graph_data{autovacuum_min} .= "[$t, " . ($v_dataavg{vmin}{"$rd"} || 0) . "],";
 					}
 					if (exists $v_dataavg{vcount}{"$rd"}) {

--- a/pgbadger
+++ b/pgbadger
@@ -10579,8 +10579,8 @@ sub print_vacuum
 		);
 
 		$drawn_graphs{autovacuumspersecond_graph} = &jqplot_linegraph($graphid++, 'autovacuumspersecond_graph', $graph_data{autovacuum_max},
-		$graph_data{autovacuum_avg}, $graph_data{autovacuum_min}, 'Autovacuums per second (' . $avg_minutes . ' minutes average)',
-		'Autovacuums per second', 'Maximum', 'Average', 'Mininum'
+		$graph_data{autovacuum_avg}, $graph_data{autovacuum_min}, 'Average Autovacuum Duration (' . $avg_minutes . ' minutes average)',
+		'Average Autovacuum Duration', 'Maximum', 'Average', 'Mininum'
 		);
 
 	}
@@ -10630,7 +10630,7 @@ $drawn_graphs{autovacuum_graph}
 
 print $fh qq{
 	<div id="autovacuums-per-second" class="analysis-item row">
-	<h2 class="col-md-12"><i class="glyphicon icon-pencil"></i> Autovacuums per second</h2>
+	<h2 class="col-md-12"><i class="glyphicon icon-pencil"></i> Average Autovacuum Duration</h2>
 	<div class="col-md-3">
 		<h3 class="">Key values</h3>
 		<div class="well key-figures">

--- a/pgbadger
+++ b/pgbadger
@@ -16669,12 +16669,14 @@ sub parse_query
 	# Store autoanalyze information
 	if (
 		$is_log_level
-		&& ($prefix_vars{'t_query'} =~ /automatic analyze of table "([^\s]+)"/)
-	   )
+		&& ($prefix_vars{'t_query'} =~ /automatic analyze of table "([^\s]+)" system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*) (?:sec|s)/))
 	{
 		return if ($disable_autovacuum);
 		my $table = $1;
-		$table =~ /^([^\.]+)\./;
+		my $user_time = $2;
+		my $system_time = $3;
+		my $elapsed_time = $4;
+		$table =~ /^([^.]+)\./;
 		$curdb = $1;
 		if (!$report_per_database) {
 			$curdb = $DBALL;
@@ -16683,12 +16685,10 @@ sub parse_query
 		$autoanalyze_info{$curdb}{tables}{$table}{analyzes} += 1;
 		$autoanalyze_info{$curdb}{chronos}{$date_part}{$prefix_vars{'t_hour'}}{count}++;
 		$per_minute_info{$curdb}{$date_part}{$prefix_vars{'t_hour'}}{$prefix_vars{'t_min'}}{autoanalyze}{count}++;
-		if ($prefix_vars{'t_query'} =~ m#system usage: CPU .* (?:sec|s,) elapsed (.*) s#) {
-			if ($1 > $autoanalyze_info{$curdb}{peak}{system_usage}{elapsed}) {
-				$autoanalyze_info{$curdb}{peak}{system_usage}{elapsed} = $1;
-				$autoanalyze_info{$curdb}{peak}{system_usage}{table} = $table;
-				$autoanalyze_info{$curdb}{peak}{system_usage}{date} = $cur_last_log_timestamp;
-			}
+		if ($elapsed_time > $autoanalyze_info{$curdb}{peak}{system_usage}{elapsed}) {
+			$autoanalyze_info{$curdb}{peak}{system_usage}{elapsed} = $elapsed_time;
+			$autoanalyze_info{$curdb}{peak}{system_usage}{table} = $table;
+			$autoanalyze_info{$curdb}{peak}{system_usage}{date} = $cur_last_log_timestamp;
 		}
 	}
 

--- a/pgbadger
+++ b/pgbadger
@@ -10518,6 +10518,15 @@ sub print_vacuum
 
 				if (exists $per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}) {
 					$v_dataavg{vcount}{"$rd"} += ($per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{count} || 0);
+
+					# Search minimum and maximum during this minute
+					foreach my $s (keys %{$per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{second}}) {
+						$v_dataavg{vmax}{"$rd"} = $per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{second}{$s}
+							if ($per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{second}{$s} > $v_dataavg{vmax}{"$rd"});
+						$v_dataavg{vmin}{"$rd"} = $per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{second}{$s}
+							if ($per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum}{second}{$d} < $v_dataavg{vmin}{"$rd"});
+					}
+					delete $per_minute_info{$curdb}{$tm}{$h}{$m}{autovacuum};
 				}
 				if (exists $per_minute_info{$curdb}{$tm}{$h}{$m}{autoanalyze}) {
 					$v_dataavg{acount}{"$rd"} += ($per_minute_info{$curdb}{$tm}{$h}{$m}{autoanalyze}{count} || 0);

--- a/pgbadger
+++ b/pgbadger
@@ -10571,11 +10571,18 @@ sub print_vacuum
 	}
 	# VACUUMs vs ANALYZEs chart
 	$drawn_graphs{autovacuum_graph} = $NODATA;
+	$drawn_graphs{autovacuumpersecond_graph} = $NODATA;
 	if ($graph)
 	{
 		$drawn_graphs{autovacuum_graph} = &jqplot_linegraph($graphid++, 'autovacuum_graph', $graph_data{vcount}, $graph_data{acount},
 		'', 'Autovacuum actions (' . $avg_minutes . ' minutes period)', '', 'VACUUMs', 'ANALYZEs'
 		);
+
+		$drawn_graphs{autovacuumspersecond_graph} = &jqplot_linegraph($graphid++, 'autovacuumspersecond_graph', $graph_data{autovacuum_max},
+		$graph_data{autovacuum_avg}, $graph_data{autovacuum_min}, 'Autovacuums per second (' . $avg_minutes . ' minutes average)',
+		'Autovacuums per second', 'Maximum', 'Average', 'Mininum'
+		);
+
 	}
 
 	my $vacuum_size_peak = 0;
@@ -10618,6 +10625,23 @@ sub print_vacuum
 $drawn_graphs{autovacuum_graph}
 		</div>
 	</div><!-- end of Autovacuum actions -->
+};
+	delete $drawn_graphs{autovacuum_graph};
+
+print $fh qq{
+	<div id="autovacuums-per-second" class="analysis-item row">
+	<h2 class="col-md-12"><i class="glyphicon icon-pencil"></i> Autovacuums per second</h2>
+	<div class="col-md-3">
+		<h3 class="">Key values</h3>
+		<div class="well key-figures">
+			<ul>
+			</ul>
+		</div>
+	</div>
+	<div class="col-md-9">
+$drawn_graphs{autovacuumspersecond_graph}
+		</div>
+	</div><!-- end of autovacuums-per-second actions -->
 };
 	delete $drawn_graphs{autovacuum_graph};
 

--- a/pgbadger
+++ b/pgbadger
@@ -4972,9 +4972,12 @@ sub parse_orphan_line
 		}
 		if ($line =~ /^[\s\t]*system usage: CPU: user: (.*) (?:sec|s,) system: (.*) (?:sec|s,) elapsed: (.*)/)
 		{
-			if ($1 > $autovacuum_info{$curdb}{peak}{system_usage}{elapsed})
+			# Add vacuum counts and duration to the $per_minute_info.
+			$per_minute_info{$curdb}{$date_part}{$cur_info{$cur_pid}{hour}}{$cur_info{$cur_pid}{min}}{autovacuum}{count}++;
+			$per_minute_info{$curdb}{$date_part}{$cur_info{$cur_pid}{hour}}{$cur_info{$cur_pid}{min}}{autovacuum}{second}{$cur_info{$cur_pid}{second}} += $3;
+			if ($3 > $autovacuum_info{$curdb}{peak}{system_usage}{elapsed})
 			{
-				$autovacuum_info{$curdb}{peak}{system_usage}{elapsed} = $1;
+				$autovacuum_info{$curdb}{peak}{system_usage}{elapsed} = $3;
 				$autovacuum_info{$curdb}{peak}{system_usage}{table} = $cur_info{$cur_pid}{vacuum};
 				$autovacuum_info{$curdb}{peak}{system_usage}{date} =
 					"$cur_info{$cur_pid}{year}-$cur_info{$cur_pid}{month}-$cur_info{$cur_pid}{day} " .


### PR DESCRIPTION
Hello 👋🏽 

I thought this would be an interesting feature to add as one can have a decent average autovacuum duration, but some of them might be running too long and one wouldn't know it.

While trying to implement this feature, I stumbled upon the fact that the parsing for `autovacuum`'s `system usage: CPU: user: ...` line is broken. I hadn't noticed it thus far, but have checked a report I generated a couple of days ago and it's also missing the longest vacuum duration:

![image](https://github.com/darold/pgbadger/assets/36642413/f32e595a-c027-43f1-aea3-3cdd319bb156)

So, I fixed that, and begun implementing the chart.

To test my implementation, I generated a report from the following output:

<details><summary>Details</summary>
<p>

```sql
Feb 10 23:06:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:08:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:10:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:12:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:14:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:16:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:18:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:20:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:22:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:24:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28
Feb 10 23:26:30 test-pc postgres[10808]: [1-1] db=,user=,app=,client= LOG:  automatic vacuum of table "db.public.tablename": index scans: 1
									    pages: 0 removed, 1001527 remain, 0 skipped due to pins, 0 skipped frozen
									    tuples: 1346603 removed, 15288094 remain, 224598 are dead but not yet removable, oldest xmin: 736
									    buffer usage: 1104110 hits, 2210831 misses, 1716564 dirtied
									    avg read rate: 2.329 MB/s, avg write rate: 1.808 MB/s
									    system usage: CPU: user: 46.90 s, system: 60.02 s, elapsed: 7417.28

``` 

</p>
</details> 

The result (I know it's missing the `Key Values`, I just wanted to get the biggest part out of the way) is:

![image](https://github.com/darold/pgbadger/assets/36642413/b2312348-10f2-4301-afd2-e008dd77055d)

This seems decent enough, but I might be forgetting something, but I guess we can cross that bridge when we cross it.

Looking forward to hear from you, Gilles!